### PR TITLE
Final merge of old upgrade-148 branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,17 +357,6 @@
         </dependency>
     </dependencies>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>nexus-snapshots</id>
-            <url>http://nexus.vertigo.stitchfix.com/nexus/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>nexus-releases</id>
-            <url>http://nexus.vertigo.stitchfix.com/nexus/content/repositories/releases</url>
-        </repository>
-    </distributionManagement>
-
     <build>
         <plugins>
             <plugin>
@@ -423,20 +412,7 @@
                 </executions>
             </plugin>
             -->
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
-                <executions>
-                    <execution>
-                        <id>default-deploy</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>deploy</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+         </plugins>
     </build>
 
     <profiles>


### PR DESCRIPTION
This merges the upgrade-148 branch that was merged into qubole's repo.  This only adds the "undo pom additions" commit as everything else was merged already.

Have already moved our other commits out of master into stitchfix-master so now we can more easily synch up our fork.